### PR TITLE
Fixed middleware issue

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -15,13 +15,13 @@ class GroupController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
-        $this->middleware('user.group');
+        $this->middleware('user.group')->except('store');
     }
 
     /**
      * Store a newly created group in storage.
      *
-     * @param GroupStoreRequest $request
+     * @param GroupStoreRequest $requestgit sta
      * @param IGroupRepository $group
      * @return \Illuminate\Http\RedirectResponse
      */


### PR DESCRIPTION
It's checking if the user belongs to the group, but when storing a new group you're not part of that group yet because it obviously does not exist. So in that case, you only need to be authenticated.